### PR TITLE
fix: problems with spaces and invalid seq indent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "chai": "4.2.0",
         "mocha": "8.1.1",
         "rimraf": "*",
-        "typescript": "3.0.1"
+        "typescript": "^4.0.5"
       }
     },
     "node_modules/@types/chai": {
@@ -1396,9 +1396,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2776,9 +2776,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "chai": "4.2.0",
     "mocha": "8.1.1",
     "rimraf": "*",
-    "typescript": "3.0.1"
+    "typescript": "^4.0.5"
   }
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -379,7 +379,8 @@ function storeMappingPair(
   _result:ast.YamlMap,
   keyTag,
   keyNode:ast.YAMLNode,
-  valueNode:ast.YAMLNode
+  valueNode:ast.YAMLNode,
+  nodeIndent: number
 ):ast.YamlMap {
 
   if (keyNode==null){
@@ -398,14 +399,16 @@ function storeMappingPair(
       endPosition: endPosition,
       parent:null,
       errors:[],
-      mappings: [],kind:ast.Kind.MAP
+      mappings: [],
+      kind: ast.Kind.MAP,
+      nodeIndent,
     };
   }
-  var mapping=ast.newMapping(<ast.YAMLNode>keyNode,valueNode);
-  mapping.parent=_result;
-  keyNode.parent=mapping;
+  var mapping = ast.newMapping(<ast.YAMLNode>keyNode, valueNode, nodeIndent);
+  mapping.parent = _result;
+  keyNode.parent = mapping;
 
-  if (valueNode!=null) {
+  if (valueNode != null) {
       valueNode.parent = mapping;
   }
 
@@ -473,7 +476,7 @@ function positionToLine(state: State, position: number): Line {
     return line;
 }
 
-function skipSeparationSpace(state:State, allowComments, checkIndent) {
+function skipSeparationSpace(state:State, allowComments, nodeIndent, toEndBlock = false) {
   var lineBreaks = 0,
       ch = state.input.charCodeAt(state.position);
 
@@ -492,6 +495,10 @@ function skipSeparationSpace(state:State, allowComments, checkIndent) {
     }
 
     if (is_EOL(ch)) {
+      if (toEndBlock && -1 !== nodeIndent && state.lineIndent < nodeIndent) {
+        state.position -= state.lineIndent;
+        break;
+      }
       readLineBreak(state);
 
       ch = state.input.charCodeAt(state.position);
@@ -507,7 +514,7 @@ function skipSeparationSpace(state:State, allowComments, checkIndent) {
     }
   }
 
-  if (-1 !== checkIndent && 0 !== lineBreaks && state.lineIndent < checkIndent) {
+  if (-1 !== nodeIndent && 0 !== lineBreaks && state.lineIndent < nodeIndent) {
     throwWarning(state, 'deficient indentation');
   }
 
@@ -559,7 +566,7 @@ function readPlainScalar(state:State, nodeIndent, withinFlowCollection) {
       _kind = state.kind,
       _result = state.result,
       ch;
-  var state_result=ast.newScalar();
+  var state_result = ast.newScalar('', nodeIndent);
   state_result.plainScalar=true;
   state.result=state_result;
   ch = state.input.charCodeAt(state.position);
@@ -674,11 +681,11 @@ function readSingleQuotedScalar(state:State, nodeIndent) {
   if (0x27/* ' */ !== ch) {
     return false;
   }
-  var scalar=ast.newScalar();
+  var scalar = ast.newScalar('', nodeIndent);
   scalar.singleQuoted=true;
   state.kind = 'scalar';
   state.result = scalar;
-    scalar.startPosition=state.position;
+  scalar.startPosition = state.position;
 
     state.position++;
   captureStart = captureEnd = state.position;
@@ -729,7 +736,7 @@ function readDoubleQuotedScalar(state:State, nodeIndent:number) {
   }
 
   state.kind = 'scalar';
-  var scalar=ast.newScalar();
+  var scalar = ast.newScalar('', nodeIndent);
   scalar.doubleQuoted=true;
   state.result = scalar;
     scalar.startPosition=state.position;
@@ -823,7 +830,7 @@ function readFlowCollection(state:State, nodeIndent) {
   } else if (ch === 0x7B/* { */) {
     terminator = 0x7D;/* } */
     isMapping = true;
-    _result = ast.newMap();
+    _result = ast.newMap(null, nodeIndent);
     _result.startPosition=state.position
   } else {
     return false;
@@ -885,9 +892,9 @@ function readFlowCollection(state:State, nodeIndent) {
     }
 
     if (isMapping) {
-      storeMappingPair(state, (<ast.YamlMap>_result), keyTag, keyNode, valueNode);
+      storeMappingPair(state, (<ast.YamlMap>_result), keyTag, keyNode, valueNode, nodeIndent);
     } else if (isPair) {
-        var mp=storeMappingPair(state, null, keyTag, keyNode, valueNode);
+        var mp = storeMappingPair(state, null, keyTag, keyNode, valueNode, nodeIndent);
         mp.parent=_result;
         (<ast.YAMLSequence>_result).items.push(mp);
     } else {
@@ -932,7 +939,7 @@ function readBlockScalar(state:State, nodeIndent) {
   } else {
     return false;
   }
-  var sc=ast.newScalar();
+  var sc = ast.newScalar('', nodeIndent);
   state.kind = 'scalar';
   state.result = sc;
   sc.startPosition=state.position
@@ -1116,8 +1123,9 @@ function readBlockSequence(state:State, nodeIndent) {
       state.result.parent = _result;
       _result.items.push(state.result);
     }
-    _result.endPosition = state?.result?.endPosition || state.position;
-    skipSeparationSpace(state, true, -1);
+
+    skipSeparationSpace(state, true, nodeIndent, true);
+    _result.endPosition = state.position - 1;
 
     ch = state.input.charCodeAt(state.position);
 
@@ -1144,7 +1152,7 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
       _line,
       _tag          = state.tag,
       _anchor       = state.anchor,
-      _result       = ast.newMap(),
+      _result       = ast.newMap(null, nodeIndent),
       keyTag        = null,
       keyNode       = null,
       valueNode     = null,
@@ -1171,7 +1179,7 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
 
       if (0x3F/* ? */ === ch) {
         if (atExplicitKey) {
-          storeMappingPair(state, _result, keyTag, keyNode, null);
+          storeMappingPair(state, _result, keyTag, keyNode, null, nodeIndent);
           keyTag = keyNode = valueNode = null;
         }
 
@@ -1211,7 +1219,7 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
           }
 
           if (atExplicitKey) {
-            storeMappingPair(state, _result, keyTag, keyNode, null);
+            storeMappingPair(state, _result, keyTag, keyNode, null, nodeIndent);
             keyTag = keyNode = valueNode = null;
           }
 
@@ -1250,7 +1258,7 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
         keyNode.value = state.input.substring(state.result.startPosition, state.position - 1);
         keyNode.rawValue = keyNode.value;
         keyNode.endPosition = state.position - 1;
-        storeMappingPair(state, _result, keyTag, keyNode, null);
+        storeMappingPair(state, _result, keyTag, keyNode, null, nodeIndent);
       } else {
         state.tag = _tag;
         state.anchor = _anchor;
@@ -1266,6 +1274,10 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
     //
     if (state.line === _line || state.lineIndent > nodeIndent) {
       if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (state.lineIndent && nodeIndent && state.lineIndent >= nodeIndent) {
+          skipSeparationSpace(state, true, nodeIndent, true);
+          state.result.endPosition = state.position - 1;
+        }
         if (atExplicitKey) {
           keyNode = state.result;
         } else {
@@ -1274,7 +1286,9 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
       }
 
       if (!atExplicitKey) {
-        storeMappingPair(state, _result, keyTag, keyNode, valueNode);
+        if (keyNode?.endPosition) keyNode.endPosition = state.position - 1;
+        if (valueNode?.endPosition) valueNode.endPosition = state.position - 1;
+        storeMappingPair(state, _result, keyTag, keyNode, valueNode, nodeIndent);
         keyTag = keyNode = valueNode = null;
       }
 
@@ -1297,7 +1311,7 @@ function readBlockMapping(state:State, nodeIndent, flowIndent) {
 
   // Special case: last mapping's node contains only the key in explicit notation.
   if (atExplicitKey) {
-    storeMappingPair(state, _result, keyTag, keyNode, null);
+    storeMappingPair(state, _result, keyTag, keyNode, null, nodeIndent);
   }
 
   // Expose the resulting mapping.
@@ -1468,7 +1482,7 @@ function readAlias(state:State) {
     }
   }
 
-  state.result = ast.newAnchorRef(alias,_position,state.position,state.anchorMap[alias]);
+  state.result = ast.newAnchorRef(alias, _position, state.position, state.anchorMap[alias], 0);
   skipSeparationSpace(state, true, -1);
   return true;
 }
@@ -1585,7 +1599,7 @@ function composeNode(state:State, parentIndent, nodeContext, allowToSeek, allowC
   if (null !== state.tag && '!' !== state.tag) {
     if (state.tag=="!include"){
         if (!state.result){
-            state.result=ast.newScalar();
+            state.result = ast.newScalar('', blockIndent);
             state.result.startPosition=state.position;
             state.result.endPosition=state.position;
             throwError(state,"!include without value");

--- a/src/yamlAST.ts
+++ b/src/yamlAST.ts
@@ -20,6 +20,7 @@ export interface YAMLDocument {
 export interface YAMLNode extends YAMLDocument {
     startPosition: number
     endPosition: number
+    nodeIndent: number
     kind: Kind
     anchorId?: string
     valueObject?: any
@@ -63,12 +64,13 @@ export interface YAMLSequence extends YAMLNode {
 export interface YamlMap extends YAMLNode {
     mappings: YAMLMapping[]
 }
-export function newMapping(key: YAMLNode, value: YAMLNode): YAMLMapping {
+export function newMapping(key: YAMLNode, value: YAMLNode, nodeIndent: number = 2): YAMLMapping {
     var end = (value ? value.endPosition : key.endPosition + 1); //FIXME.workaround, end should be defied by position of ':'
     //console.log('key: ' + key.value + ' ' + key.startPosition + '..' + key.endPosition + ' ' + value + ' end: ' + end);
     var node = {
         key: key,
         value: value,
+        nodeIndent,
         startPosition: key.startPosition,
         endPosition: end,
         kind: Kind.MAPPING,
@@ -77,23 +79,25 @@ export function newMapping(key: YAMLNode, value: YAMLNode): YAMLMapping {
     };
     return node
 }
-export function newAnchorRef(key: string, start: number, end: number, value: YAMLNode): YAMLAnchorReference {
+export function newAnchorRef(key: string, start: number, end: number, value: YAMLNode, nodeIndent: number = 2): YAMLAnchorReference {
     return {
         errors: [],
         referencesAnchor: key,
         value: value,
+        nodeIndent,
         startPosition: start,
         endPosition: end,
         kind: Kind.ANCHOR_REF,
         parent: null
     }
 }
-export function newScalar(v: string | boolean | number = ""): YAMLScalar {
+export function newScalar(v: string | boolean | number = "", nodeIndent: number = 2): YAMLScalar {
     const result: YAMLScalar = {
         errors: [],
         startPosition: -1,
         endPosition: -1,
         value: "" + v,
+        nodeIndent,
         kind: Kind.SCALAR,
         parent: null,
         doubleQuoted: false,
@@ -109,6 +113,7 @@ export function newItems(): YAMLSequence {
         errors: [],
         startPosition: -1,
         endPosition: -1,
+        nodeIndent: 2,
         items: [],
         kind: Kind.SEQ,
         parent: null
@@ -117,11 +122,12 @@ export function newItems(): YAMLSequence {
 export function newSeq(): YAMLSequence {
     return newItems();
 }
-export function newMap(mappings?: YAMLMapping[]): YamlMap {
+export function newMap(mappings?: YAMLMapping[], nodeIndent: number = 2,): YamlMap {
     return {
         errors: [],
         startPosition: -1,
         endPosition: -1,
+        nodeIndent,
         mappings: mappings ? mappings : [],
         kind: Kind.MAP,
         parent: null

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -55,6 +55,7 @@ foo: bar`;
         endPosition: 19,
         errors: [],
         kind: 0,
+        nodeIndent: 0,
         parent: null,
         plainScalar: true,
         rawValue: 'test',
@@ -80,7 +81,7 @@ foo: bar`;
                     YAML.newScalar('tags'),
                     seq)]);
     assert.deepEqual(structure(doc), expected_structure)
-    assert.lengthOf(doc.errors, 1, `Found error(s): ${doc.errors.toString()} when expecting none.`)
+    assert.lengthOf(doc.errors, 2, `Found error(s): ${doc.errors.toString()} when expecting none.`)
   });
 
   test('should not contain spaces', function () {
@@ -119,9 +120,27 @@ newTags:
   - user
   `;
     const doc = YAML.safeLoad(input) as YamlMap;
-    console.log(doc)
 
     assert.equal(doc.endPosition, input.length);
+    assert.isTrue(doc.mappings[0].endPosition < doc.mappings[1].startPosition);
+
+    assert.lengthOf(doc.errors, 0)
+  });
+
+  test('should contain spaces between items', function () {
+    const seq = `tags:
+  - email
+  `;
+    const mapping = `
+newTags:
+  whatever: false
+  `;
+    const input = seq + mapping;
+    const doc = YAML.safeLoad(input) as YamlMap;
+
+    assert.equal(doc.endPosition, input.length);
+    assert.equal(doc.mappings[0].endPosition, seq.length);
+    assert.equal(doc.mappings[1].endPosition, input.length);
     assert.isTrue(doc.mappings[0].endPosition < doc.mappings[1].startPosition);
 
     assert.lengthOf(doc.errors, 0)

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -64,6 +64,68 @@ foo: bar`;
     );
     assert.lengthOf(doc.errors, 1, `Found error(s): ${doc.errors.toString()} when expecting none.`);
   });
+
+  test('should work with invalid multi-line key in sequence', function () {
+    const input = `tags:
+  - email
+  n `;
+    const doc = YAML.safeLoad(input) as YamlMap;
+
+    const seq = YAML.newSeq();
+    seq.items = [YAML.newScalar('email')];
+    assert.lengthOf(doc.mappings, 1);
+    const expected_structure =
+            YAML.newMap(
+                [YAML.newMapping(
+                    YAML.newScalar('tags'),
+                    seq)]);
+    assert.deepEqual(structure(doc), expected_structure)
+    assert.lengthOf(doc.errors, 1, `Found error(s): ${doc.errors.toString()} when expecting none.`)
+  });
+
+  test('should not contain spaces', function () {
+    const input = `tags:
+  - email
+ 
+ 
+ 
+ 
+  `;
+    const doc = YAML.safeLoad(input) as YamlMap;
+
+    const seq = YAML.newSeq();
+    seq.items = [YAML.newScalar('email')];
+    assert.lengthOf(doc.mappings, 1);
+    const expected_structure =
+            YAML.newMap(
+                [YAML.newMapping(
+                    YAML.newScalar('tags'),
+                    seq)]);
+
+    assert.equal(doc.endPosition, input.length);
+    assert.equal(doc.mappings[0].startPosition, 0);
+    assert.equal(doc.mappings[0].endPosition, 15);
+
+    assert.deepEqual(structure(doc), expected_structure)
+    assert.lengthOf(doc.errors, 0)
+  });
+
+  test('should not contain spaces between items', function () {
+    const input = `tags:
+  - email
+ 
+ 
+newTags:
+  - user
+  `;
+    const doc = YAML.safeLoad(input) as YamlMap;
+    console.log(doc)
+
+    assert.equal(doc.endPosition, input.length);
+    assert.isTrue(doc.mappings[0].endPosition < doc.mappings[1].startPosition);
+
+    assert.lengthOf(doc.errors, 0)
+  });
 });
 
 suite('Loading multiple documents', () => {


### PR DESCRIPTION
## What/Why/How?

1. end point of sequence belongs to next node
```
tags: 
  - name
  
newTags:
  - email
```
2. consumes empty lines
```
tags: 
  - name
    
 
key: value
```
3. skipped dash in sequence breaks document (same for empty space after text)
```
tags: 
  - name
   some t
```
4. Add `nodeIndent` to all nodes
5. improve node positions

## Reference

## Testing
1. Test lib on `openapi-cli`.
2. Test with petstore.

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
